### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,13 +85,13 @@ For example, you could group dictionaries:
    :target: https://coveralls.io/r/themattrix/python-group-by-attr
 .. |Health| image:: https://landscape.io/github/themattrix/python-group-by-attr/master/landscape.svg
    :target: https://landscape.io/github/themattrix/python-group-by-attr/master
-.. |Version| image:: https://pypip.in/version/group_by_attr/badge.svg?text=version
+.. |Version| image:: https://img.shields.io/pypi/v/group_by_attr.svg?label=version
     :target: https://pypi.python.org/pypi/group-by-attr
-.. |Downloads| image:: https://pypip.in/download/group_by_attr/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/group_by_attr.svg
     :target: https://pypi.python.org/pypi/group-by-attr
-.. |Compatibility| image:: https://pypip.in/py_versions/group_by_attr/badge.svg
+.. |Compatibility| image:: https://img.shields.io/pypi/pyversions/group_by_attr.svg
     :target: https://pypi.python.org/pypi/group-by-attr
-.. |Implementations| image:: https://pypip.in/implementation/group_by_attr/badge.svg
+.. |Implementations| image:: https://img.shields.io/pypi/implementation/group_by_attr.svg
     :target: https://pypi.python.org/pypi/group-by-attr
-.. |Format| image:: https://pypip.in/format/group_by_attr/badge.svg
+.. |Format| image:: https://img.shields.io/pypi/format/group_by_attr.svg
     :target: https://pypi.python.org/pypi/group-by-attr


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20group-by-attr))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `group-by-attr`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.